### PR TITLE
Update Server to use bdickason.com and proper endpoints

### DIFF
--- a/ios/t7ChickenNative/Info.plist
+++ b/ios/t7ChickenNative/Info.plist
@@ -46,7 +46,7 @@
       <true/>
       <key>NSExceptionDomains</key>
       <dict>
-        <key>chicken.seattletekken.com</key>
+        <key>bdickason.com</key>
         <dict>
           <key>NSExceptionRequiresForwardSecrecy</key>
           <false/>

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
     "reactotron-react-native": "^1.6.0"
   },
   "jest": {
-    "preset": "react-native"
+    "preset": "react-native",
+    "setupFiles": ["./test/setup.js"],
+    "transformIgnorePatterns": [
+     "node_modules/(?!(jest-)?react-native|react-navigation)"
+   ]
   }
 }

--- a/src/redux/actions/blob.js
+++ b/src/redux/actions/blob.js
@@ -8,7 +8,7 @@ export const BLOB_UPDATE_DATA = 'BLOB_UPDATE_DATA';
 export const BLOB_FETCH_SUCCESS = 'BLOB_FETCH_SUCCESS';
 export const BLOB_FETCH_ERROR = 'BLOB_FETCH_ERROR';
 
-const CHAR_DATA_API = "http://chicken.seattletekken.com/api.php";
+const CHAR_DATA_API = "http://bdickason.com:3001/api/metadata";
 const DATA_VER_API = "";
 
 /**

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,7 @@
+jest.mock('Linking', () => ({
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  openURL: jest.genMockFn().mockReturnValue(Promise.resolve()),
+  canOpenURL: jest.genMockFn().mockReturnValue(Promise.resolve()),
+  getInitialURL: jest.genMockFn().mockReturnValue(Promise.resolve()),
+}))


### PR DESCRIPTION
Moving us away from the php wrapper on seattletekken.com, this change:

1. Changes the url to the metadata endpoint on bdickason.com:3001
2. Adds bdickason.com to the security domain whitelist for accepted http requests