### PR TITLE
Updated server to point to Cloudfront CDN

### DIFF
--- a/ios/T7Chicken/Info.plist
+++ b/ios/T7Chicken/Info.plist
@@ -48,7 +48,7 @@
 		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>bdickason.com</key>
+			<key>api.tekkenchicken.com</key>
 			<dict>
 				<key>NSExceptionRequiresForwardSecrecy</key>
 				<false/>

--- a/src/redux/actions/blob.js
+++ b/src/redux/actions/blob.js
@@ -8,8 +8,8 @@ export const BLOB_UPDATE_DATA = 'BLOB_UPDATE_DATA';
 export const BLOB_FETCH_SUCCESS = 'BLOB_FETCH_SUCCESS';
 export const BLOB_FETCH_ERROR = 'BLOB_FETCH_ERROR';
 
-const CHAR_DATA_API = "http://bdickason.com:3002/api/framedata/";
-const CHAR_METADATA_API = "http://bdickason.com:3002/api/metadata/"
+const CHAR_DATA_API = "http://api.tekkenchicken.com/api/framedata/";
+const CHAR_METADATA_API = "http://api.tekkenchicken.com/api/metadata/"
 
 /**
  *  @method: checkDataVersion


### PR DESCRIPTION
This will help us out in a few ways:
1. All changes are now cached externally for 10m (so our server only gets hit once per 10m)
2. All cache files are replicated throughout the globe to local edges
3. Our actual server URL is not exposed to the world
4. Any DDOS attacks hit Amazon who can handle them