### PR TITLE
Fixes bundle error when running react-native run-ios

### DIFF
--- a/ios/T7Chicken/AppDelegate.m
+++ b/ios/T7Chicken/AppDelegate.m
@@ -18,7 +18,7 @@
 {
   NSURL *jsCodeLocation;
 
-  //jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
+  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"T7Chicken"


### PR DESCRIPTION
This solves the 'red screen of death' that @dxn7335 ran into earlier. The app also still builds properly in Xcode so it shouldn't break anything.