### PR TITLE
Feature/filter improvement

### DIFF
--- a/src/containers/AttackDetails/index.js
+++ b/src/containers/AttackDetails/index.js
@@ -98,7 +98,7 @@ class AttackDetails extends Component {
 
 const mapStateToProps = state => {
     return {
-      character: state.character.data,
+      character: state.character.filteredMoves,
       selectedMove: state.attackDetails.move,
       index: state.attackDetails.index,
     }

--- a/src/containers/CharacterProfile/MoveList.js
+++ b/src/containers/CharacterProfile/MoveList.js
@@ -18,9 +18,6 @@ import DataList from '../../components/DataList/DataList';
 import FrameDataCard from '../../components/FrameData/FrameDataCard';
 import Spreadsheet from '../../components/Spreadsheet/';
 
-// Utils
-import MoveFiltersUtil from '../../util/moveFilters/moveFiltersUtil';
-
 import * as Colors from '../../style/vars/colors';
 
 //actions
@@ -53,10 +50,7 @@ class MoveList extends Component {
   }
 
   render() {
-    // Filter and Search Move Data before rendering
-    let moves = MoveFiltersUtil.filterMoves(this.props.moves, this.props.filter);
-    moves = MoveFiltersUtil.searchByNotation(moves, this.props.searchNotation);
-    const { isPortrait } = this.props;
+    const { isPortrait, moves } = this.props;
     return (
       <View style={Styles.container}>
         <View>

--- a/src/containers/CharacterProfile/index.js
+++ b/src/containers/CharacterProfile/index.js
@@ -227,7 +227,7 @@ const mapStateToProps = (state, props) => {
   return {
     characterID: props.navigation.state.params.characterID,
     characterName: props.navigation.state.params.characterName,
-    characterMovesData: state.character.data
+    characterMovesData: state.character.filteredMoves
   };
 };
 

--- a/src/containers/CharacterProfile/index.js
+++ b/src/containers/CharacterProfile/index.js
@@ -148,7 +148,6 @@ class CharacterProfileScreen extends Component {
 
   render() {
     const {characterID, characterMovesData, characterName} = this.props;
-    console.log('characterMovesData', characterMovesData)
     // const scrollStateOffset = (this.props.navigation.state.params.scrollHeader) ? Styles.offsetOnScroll : '';
     const menu = <FilterMenuContainer />;
     return (

--- a/src/redux/actions/character.js
+++ b/src/redux/actions/character.js
@@ -1,5 +1,9 @@
+import MoveFiltersUtil from '../../util/moveFilters/moveFiltersUtil'
+import { BLOB_UPDATE_DATA } from './blob';
+
 // Action Types
 export const CHARACTER_SET_DATA = 'CHARACTER_SET_DATA';
+export const CHARACTER_UPDATE_DATA = 'CHARACTER_UPDATE_DATA';
 export const CHARACTER_RESET_DATA = 'CHARACTER_RESET_DATA';
 export const CHARACTER_FILTER_MOVES = 'CHARACTER_FILTER_MOVES';
 export const CHARACTER_SEARCH_MOVES = 'CHARACTER_SEARCH_MOVES';
@@ -26,6 +30,12 @@ export const fetchDataForCharacter = (characterID) => {
     return dispatch(setCharacterData(charData));
   };
 };
+
+export const updateCharacterData = () => {
+  return {
+    type: CHARACTER_UPDATE_DATA
+  }
+}
 
 /**
  *  @method resetDataForCharacter
@@ -54,13 +64,14 @@ export const applyCharacterMoveFilters = () => {
  *  @param {boolean} addFlag
  *  A key (obj property) and a value associated to the key will be received and used to update the filterQueue state
  */
-export const queueCharacterMoveFilters = (key, value, addFlag) => {
-  return {
+export const queueCharacterMoveFilters = (key, value, addFlag) => dispatch => {
+  dispatch({
     type: CHARACTER_QUEUE_FILTERS,
     key,
     value,
     addFlag
-  };
+  });
+  dispatch(updateCharacterData())
 };
 
 /**

--- a/src/redux/actions/character.js
+++ b/src/redux/actions/character.js
@@ -88,9 +88,11 @@ export const resetCharacterMoveFilters = () => {
  *  @method searchMovesByNotation
  *  Trigger action to filter moves by user notation inputted
  */
-export const searchMovesByNotation = (notation) => {
-  return {
-    type: CHARACTER_SEARCH_MOVES,
-    notation: notation.trim().replace(/\s/g,'')
-  };
+export const searchMovesByNotation = (notation) => dispatch => {
+  dispatch({ type: CHARACTER_SEARCH_MOVES, notation: notation.trim().replace(/\s/g, '')})
+  dispatch(updateCharacterData())
+  // return {
+  //   type: CHARACTER_SEARCH_MOVES,
+  //   notation: notation.trim().replace(/\s/g,'')
+  // };
 };

--- a/src/redux/reducers/character.js
+++ b/src/redux/reducers/character.js
@@ -6,15 +6,19 @@ import {
   CHARACTER_SEARCH_MOVES,
   CHARACTER_APPLY_FILTERS,
   CHARACTER_QUEUE_FILTERS,
-  CHARACTER_RESET_FILTERS
+  CHARACTER_RESET_FILTERS,
+  CHARACTER_UPDATE_DATA
 } from '../actions/character';
+
+import MoveFiltersUtil from '../../util/moveFilters/moveFiltersUtil';
 
 const initialState = {
   name: '',
   data: [], // all moves
   filter: {},
   filterQueue: {},
-  searchNotation: ''
+  searchNotation: '',
+  filteredMoves: [] //filtered moves
 };
 
 /**
@@ -42,17 +46,25 @@ const updateFilterQueue = (currentQueue, action) => {
   return queue;
 };
 
+const filterData = (currentMoves, filter, searchNotation) => {
+  let moves = MoveFiltersUtil.filterMoves(currentMoves, filter);
+  moves = MoveFiltersUtil.searchByNotation(moves, searchNotation);
+  return moves;
+}
+
 
 function character( state = initialState, action ) {
   switch(action.type) {
     case CHARACTER_SET_DATA:
-      return Object.assign({}, state, action.data);
+      return Object.assign({}, state, action.data, {filteredMoves: action.data.data});
     case CHARACTER_RESET_DATA:
       return initialState;
     case CHARACTER_APPLY_FILTERS:
       return Object.assign({}, state, { filter: state.filterQueue });
     case CHARACTER_QUEUE_FILTERS:
       return Object.assign({}, state, { filterQueue: updateFilterQueue(state.filterQueue, action) });
+    case CHARACTER_UPDATE_DATA:
+      return Object.assign({}, state, {filteredMoves: filterData(state.data, state.filterQueue, state.searchNotation)})
     case CHARACTER_RESET_FILTERS:
       return Object.assign({}, state, { filterQueue: {} });
     case CHARACTER_SEARCH_MOVES:

--- a/src/redux/reducers/character.js
+++ b/src/redux/reducers/character.js
@@ -47,6 +47,7 @@ const updateFilterQueue = (currentQueue, action) => {
 };
 
 const filterData = (currentMoves, filter, searchNotation) => {
+  console.log('search notation tho', searchNotation)
   let moves = MoveFiltersUtil.filterMoves(currentMoves, filter);
   moves = MoveFiltersUtil.searchByNotation(moves, searchNotation);
   return moves;


### PR DESCRIPTION
I made this branch off of android-stick-header.

The main idea for this fix was so that when you go to the Attack Details page, you can cycle through the filtered attacks. Before it only cycled through the initial array of attack data